### PR TITLE
Implement custom DNS server specification in nameserver_info module

### DIFF
--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -132,14 +132,14 @@ class SimpleResolver(_Resolve):
 
 
 class ResolveDirectlyFromNameServers(_Resolve):
-    def __init__(self, timeout=10, timeout_retries=3, servfail_retries=0, always_ask_default_resolver=True):
+    def __init__(self, timeout=10, timeout_retries=3, servfail_retries=0, always_ask_default_resolver=True, server_addresses=None):
         super(ResolveDirectlyFromNameServers, self).__init__(
             timeout=timeout,
             timeout_retries=timeout_retries,
             servfail_retries=servfail_retries,
         )
         self.cache = {}
-        self.default_nameservers = self.default_resolver.nameservers
+        self.default_nameservers = self.default_resolver.nameservers if server_addresses is None else server_addresses
         self.always_ask_default_resolver = always_ask_default_resolver
 
     def _lookup_ns_names(self, target, nameservers=None, nameserver_ips=None):
@@ -221,6 +221,8 @@ class ResolveDirectlyFromNameServers(_Resolve):
         return result
 
     def _get_resolver(self, dnsname, nameservers):
+        if self.default_nameservers != self.default_resolver.nameservers:
+            nameservers = self.default_nameservers
         cache_index = ('|'.join([str(dnsname)] + sorted(nameservers)), 'resolver')
         resolver = self.cache.get(cache_index)
         if resolver is None:

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -127,6 +127,7 @@ def main():
             query_timeout=dict(type='float', default=10),
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
+            servers=dict(required=False, type='list', elements='str'),
         ),
         supports_check_mode=True,
     )
@@ -135,11 +136,14 @@ def main():
     names = module.params['name']
     resolve_addresses = module.params['resolve_addresses']
 
+    servers = module.params['servers']
+    
     resolver = ResolveDirectlyFromNameServers(
         timeout=module.params['query_timeout'],
         timeout_retries=module.params['query_retry'],
         servfail_retries=module.params['servfail_retries'],
         always_ask_default_resolver=module.params['always_ask_default_resolver'],
+        server_addresses=servers,
     )
     results = [None] * len(names)
     for index, name in enumerate(names):


### PR DESCRIPTION
Implement custom DNS server specification in nameserver_info module

This merge request introduces the ability to specify custom DNS servers for resolving nameserver information in the nameserver_info module. It includes enhancements to the ResolveDirectlyFromNameServers class to handle custom server addresses and updates the nameserver_info module to accept a new 'servers' parameter. These changes allow greater flexibility and control in DNS resolution tasks.