### PR TITLE
Implement Optional Recursive DNS Lookup in ResolveDirectlyFromNameServers

### DIFF
--- a/plugins/module_utils/resolver.py
+++ b/plugins/module_utils/resolver.py
@@ -236,8 +236,24 @@ class ResolveDirectlyFromNameServers(_Resolve):
             self.cache[cache_index] = resolver
         return resolver
 
-    def resolve_nameservers(self, target, resolve_addresses=False):
-        nameservers = self._lookup_ns(dns.name.from_unicode(to_text(target)))
+    def resolve_nameservers(self, target, resolve_addresses=False, recursive_lookup=False):
+        dnsname = dns.name.from_unicode(to_text(target))
+        original_dnsname = dnsname
+        nameservers = None
+        while not nameservers and dnsname.labels:
+            try:
+                nameservers = self._lookup_ns(dnsname)
+                if not recursive_lookup:
+                    break
+            except dns.resolver.NXDOMAIN:
+                if not recursive_lookup:
+                    raise
+                # Remove the left-most label (subdomain) to check the next higher-level domain
+                dnsname = dns.name.Name(dnsname.labels[1:])
+        
+        if not nameservers:
+            raise dns.resolver.NXDOMAIN(qnames=[original_dnsname])
+
         if resolve_addresses:
             nameserver_ips = set()
             for nameserver in nameservers:

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -67,7 +67,7 @@ options:
         default: null
     recursive_lookup:
         description:
-            - Whether to do recursive lookups when resolving nameservers for hostnames that don't exist.
+            - Whether to do recursive lookups when resolving nameservers for subdomains that don't exist.
             - When set to V(true), will return the nameservers of the closest existing parent zone.
         type: bool
         required: false

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -153,7 +153,7 @@ def main():
     resolve_addresses = module.params['resolve_addresses']
     servers = module.params['servers']
     recursive_lookup = module.params['recursive_lookup']
-    
+
     resolver = ResolveDirectlyFromNameServers(
         timeout=module.params['query_timeout'],
         timeout_retries=module.params['query_retry'],

--- a/plugins/modules/nameserver_info.py
+++ b/plugins/modules/nameserver_info.py
@@ -65,6 +65,13 @@ options:
         elements: str
         required: false
         default: null
+    recursive_lookup:
+        description:
+            - Whether to do recursive lookups when resolving nameservers for hostnames that don't exist.
+            - When set to V(true), will return the nameservers of the closest existing parent zone.
+        type: bool
+        required: false
+        default: false
 requirements:
     - dnspython >= 1.15.0 (maybe older versions also work)
 '''
@@ -136,6 +143,7 @@ def main():
             always_ask_default_resolver=dict(type='bool', default=True),
             servfail_retries=dict(type='int', default=0),
             servers=dict(required=False, type='list', elements='str'),
+            recursive_lookup=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -143,8 +151,8 @@ def main():
 
     names = module.params['name']
     resolve_addresses = module.params['resolve_addresses']
-
     servers = module.params['servers']
+    recursive_lookup = module.params['recursive_lookup']
     
     resolver = ResolveDirectlyFromNameServers(
         timeout=module.params['query_timeout'],
@@ -161,7 +169,7 @@ def main():
 
     def f():
         for index, name in enumerate(names):
-            results[index]['nameservers'] = sorted(resolver.resolve_nameservers(name, resolve_addresses=resolve_addresses))
+            results[index]['nameservers'] = sorted(resolver.resolve_nameservers(name, resolve_addresses=resolve_addresses, recursive_lookup=recursive_lookup))
 
     guarded_run(f, module, generate_additional_results=lambda: dict(results=results))
     module.exit_json(results=results)


### PR DESCRIPTION
This merge request adds an optional recursive lookup feature to the `ResolveDirectlyFromNameServers` class within `resolver.py`. It allows users to perform a recursive search for authoritative nameservers up the domain hierarchy when a specific hostname's nameserver is not found.

A new parameter `recursive_lookup` is added to `resolve_nameservers` for optional recursive domain searching.
The `nameserver_info` module is updated to support this new feature via user input.